### PR TITLE
Fixed slider images not showing up

### DIFF
--- a/src/Components/ImageSlider/Slide.js
+++ b/src/Components/ImageSlider/Slide.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Slide = ({ image }) => {
     const styles = {
-        backgroundImage: `url(img/${image}.jpg`,
+        backgroundImage: `url(${image})`,
         backgroundSize: 'cover',
         backgroundRepeat: 'no-repeat',
         backgroundPosition: '50% 60%'

--- a/src/Components/ImageSlider/Slider.js
+++ b/src/Components/ImageSlider/Slider.js
@@ -49,7 +49,9 @@ export default class Slider extends Component {
                     }}>
                     {
                         this.state.images.map((image, i) => {
-                            <Slide image={image} key={i} />
+                            return (
+                                <Slide image={image} key={i} />
+                            )
                         })
                     }
                 </div>

--- a/styles.scss
+++ b/styles.scss
@@ -30,7 +30,7 @@ nav ul {
     padding: 0;
     display: flex;
     justify-content: flex-end;
-    
+
 }
 
 .title {
@@ -53,4 +53,24 @@ nav li:hover
 {
     color: #ffc746;
     background-color:#282828;
+}
+
+
+
+/* Slider Styling */
+.slider {
+    height: 600px;
+    width: 100%;
+
+    .slider-wrapper {
+        height: 100%;
+        width: 100%;
+        overflow: hidden;
+    }
+
+    .slide {
+        height: 100%;
+        width: 100%;
+        display: inline-block;
+    }
 }


### PR DESCRIPTION
So these are the changes I made in order to get the images to show up:

**Slider.js**

```
{
    this.state.images.map((image, i) => {
        <Slide image={image} key={i} />
    })
}

```
If you use curly brackets with your arrow functions, you need to use a return statement inside of it:

```
{
    this.state.images.map((image, i) => {
        return <Slide image={image} key={i} />
    })
}
```

```
{
    this.state.images.map((image, i) => {
        return (
          <Slide image={image} key={i} />
        )
    })
}
```
^ both versions of these would work.

**Slide.js**

Since you are using webpack to handle your images, webpack is actually bundling your images into the javascript file that it produces. You are attempting to use an url that is not necessary. In my Slider example I was not using webpack to bundle my images so thats why I needed to put a path to a folder.

I removed the url and just put the name of the image inside of the styles object, and that fixes it.

**Styles.scss**

You need to set some initial height on the .slider div, or nothing else is ever going to show up. Check out starting on line 61 the styles that I created. 
This should help you start in the right direction.

P.S. I am not a fan of how the React boilerplate you are using uses the extract text plugin in dev mode. You can make things much faster if you just have your styles packed into your bundle.js in development mode.